### PR TITLE
Switching date label to a unix timestamp to avoid invalid spaces

### DIFF
--- a/scripts/deeployer-k8s
+++ b/scripts/deeployer-k8s
@@ -65,7 +65,7 @@ DIR="$( cd "$( dirname $(realpath "${BASH_SOURCE[0]}") )" >/dev/null 2>&1 && pwd
 
 config=$(cat "$DEEPLOYER_FILE")
 
-TIMESTAMP=$(date --rfc-3339=seconds)
+TIMESTAMP=$(date +%s)
 
 if [[ "$COMMAND" == "apply" ]]; then
   if [[ "$NAMESPACE" == "" ]]; then


### PR DESCRIPTION
For some reasons, labels in Kubernetes cannot have spaces.... god only knows why