### PR TITLE
Adding Kubernetes redeployment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,40 @@ You do not need to create a "cluster issuer" as Deeployer will come with its own
 
 You need to install Cert Manager v0.11+.
 
+#### Preventing automatic redeployment
+
+By default, in Kubernetes, all pods will be halted, and restarted. Even if the configuration did not change (Deeployer tries to redownload the latest version of the image).
+But in the case of some services (like a MySQL database or a Redis server), stopping and restarting the service will cause
+a disruption, for no good reason.
+
+You can tell Deeployer to not restart a pod automatically using the "redeploy": "onConfigChange" option.
+
+**deeployer.json**
+```json
+{
+  "version": "1.0",
+  "$schema": "https://raw.githubusercontent.com/thecodingmachine/deeployer/master/deeployer.schema.json",
+  "containers": {
+    "mysql": {
+      "image": "mysql:8.0",
+      "ports": [3306],
+      "env": {
+        "MYSQL_ROOT_PASSWORD": "secret"
+      },
+      "redeploy": "onConfigChange"
+    }
+  }
+}
+```
+
+
+With `"redeploy": "onConfigChange"`, your pod will be changed only if the configuration is changed.
+
+#### Redeployment strategy
+
+In Kubernetes, by default, Deeployer will stop and recreate the pod if there is only one pod (if you did not set the `replicas` property).
+If you configured `replicas` to a value greater than 1, Deeployer will use a "RollingUpdate" for this pod.
+
 ### Deploying using docker-compose
 
 To deploy with deeployer-compose, you need to setup the following alias on your local machine since deeployer in its first versions is only accessible thanks to its official docker-image :

--- a/deeployer.schema.json
+++ b/deeployer.schema.json
@@ -29,6 +29,13 @@
                 "type": "string"
               }
             },
+            "redeploy": {
+              "type": "string",
+              "enum": [
+                "always",
+                "onConfigChange"
+              ]
+            },
             "host": {
               "type": "object",
               "properties": {

--- a/tests/replicas.json
+++ b/tests/replicas.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "containers": {
+    "phpmyadmin": {
+      "image": "phpmyadmin",
+      "replicas": 3
+    }
+  }
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -18,6 +18,7 @@ expectValue "Testing https enable (issuer)" "host_with_https.json" ".generatedCo
 expectError "Testing https enable (missing mail)" "host_with_https_without_mail.json" "In order to have support for HTTPS, you need to provide an email address in the { \"config\": { \"https\": { \"mail\": \"some@email.com\" } } }" ../scripts/main.jsonnet
 expectValue "Testing the presence of a timestamp label to force reloading" "host.json" ".generatedConf.phpmyadmin.deployment.spec.template.metadata.labels.deeployerTimestamp" '"2020-05-05 00:00:00"' ../scripts/main.jsonnet
 expectValue "Testing the presence of a PVC" "volume.json" ".generatedConf.mysql.pvcs.data.spec.resources.requests.storage" '"1G"' ../scripts/main.jsonnet
+expectValue "Testing the RollingUpdate type when there are replicas" "replicas.json" ".generatedConf.phpmyadmin.deployment.spec.strategy.type" '"RollingUpdate"' ../scripts/main.jsonnet
 assertValidK8s "host.json" ../scripts/main.jsonnet
 assertValidK8s "volume.json" ../scripts/main.jsonnet
 expectValue "Testing the presence of a registry credential" "registryCredentials.json" ".generatedConf.phpmyadmin.deployment.spec.template.spec.imagePullSecrets[0].name" '"aa827ffc96199a7071140cc2267bc1b1a"' ../scripts/main.jsonnet


### PR DESCRIPTION
You can now use `"redeploy": "onConfigChange"` to restart your pod only if the configuration is changed.
Also, deployments with more than one replica are now deployed using a RollingUpdate strategy.